### PR TITLE
Scripts more clean

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -4,4 +4,11 @@
 rm -rf artifacts
 rm -rf cache
 npx hardhat compile
-npx hardhat run scripts/deploy-$1.js --network $2
+
+if [[ "$1" == "pool" ]]; then
+# bin/deploy.sh pool localhost 5000 100000000 10000000 99999
+  SYN_PER_BLOCK=$3 BLOCK_PER_UPDATE=$4 BLOCK_MULTIPIER=$5 QUICK_REWARDS=$6 \
+    npx hardhat run scripts/deploy-$1.js --network $2
+else
+  npx hardhat run scripts/deploy-$1.js --network $2
+fi

--- a/package.json
+++ b/package.json
@@ -32,13 +32,7 @@
     "compile": "npx hardhat compile",
     "size": "npx hardhat size-contracts",
     "export": "bin/exportABIs.js",
-    "lint": "prettier --write 'contracts/**/*.sol' && solhint 'contracts/**/*.sol'"
-  },
-  "dependencies": {
-    "ansi-regex": "^6.0.1",
-    "braces": "^3.0.2",
-    "dotenv": "^10.0.0",
-    "glob-parent": "^6.0.2",
-    "mem": "^9.0.1"
+    "lint": "prettier --write 'contracts/**/*.sol' && solhint 'contracts/**/*.sol'",
+    "dotenv": "^10.0.0"
   }
 }

--- a/scripts/deploy-pool.js
+++ b/scripts/deploy-pool.js
@@ -4,79 +4,50 @@
 // When running the script with `hardhat run <script>` you'll find the Hardhat
 // Runtime Environment's members available in the global scope.
 require('dotenv').config()
-const {assert} = require("chai")
 const hre = require("hardhat");
-const fs = require('fs-extra')
-const path = require('path')
 const requireOrMock = require('require-or-mock');
 const ethers = hre.ethers
 const deployed = requireOrMock('export/deployed.json')
-
-async function currentChainId() {
-  return (await ethers.provider.getNetwork()).chainId
-}
-
-function normalize(val, n = 18) {
-  return '' + val + '0'.repeat(n)
-}
+const DeployUtils = require('./lib/DeployUtils')
+let deployUtils
 
 async function main() {
-  // Hardhat always runs the compile task when running scripts with its command
-  // line interface.
-  //
-  // If this script is run directly using `node` you may want to call compile
-  // manually to make sure everything is compiled
-  // await hre.run('compile');
+  deployUtils = new DeployUtils(ethers)
+  const chainId = await deployUtils.currentChainId()
 
-  const chainId = await currentChainId()
-  const isLocalNode = /1337$/.test(chainId)
-
-  let [owner, user1, user2] = await ethers.getSigners();
-
-  // deploy the pool
+  const {SYN_PER_BLOCK, BLOCK_PER_UPDATE, BLOCK_MULTIPIER, QUICK_REWARDS} = process.env
+  if (!SYN_PER_BLOCK || !BLOCK_PER_UPDATE || !BLOCK_MULTIPIER || !QUICK_REWARDS) {
+    throw new Error('Missing parameters')
+  }
 
   const synAddress = deployed[chainId].SyndicateERC20
   const PoolFactory = await ethers.getContractFactory("SyndicatePoolFactory")
-  // console.log('pool fact')
-  // console.log(PoolFactory)
-  //   console.log("logging block number ")
-  //   console.log(await ethers.provider.getBlockNumber)
   const poolFactory = await PoolFactory.deploy(
       synAddress,
       deployed[chainId].EscrowedSyndicateERC20,
-      ethers.utils.parseEther('5000'), // synPerBlock
-      100000000, // blockPerUpdate, decrease reward by 3%
+      ethers.utils.parseEther(SYN_PER_BLOCK),
+      ethers.BigNumber.from(BLOCK_PER_UPDATE),
       await ethers.provider.getBlockNumber(),
-      await ethers.provider.getBlockNumber() + 10000000
+      (await ethers.provider.getBlockNumber()) + parseInt(BLOCK_MULTIPIER)
   );
   await poolFactory.deployed()
+  console.log('SyndicatePoolFactory deployed at', poolFactory.address)
   await poolFactory.createPool(synAddress, await ethers.provider.getBlockNumber(), 1);
 
   const corePoolAddress = await poolFactory.getPoolAddress(synAddress)
   const SyndicateCorePool = await ethers.getContractFactory("SyndicateCorePool")
   const corePool = await SyndicateCorePool.attach(corePoolAddress)
-  corePool.setQuickReward(99999)
+  await corePool.deployed()
+  console.log('SyndicateCorePool deployed at', corePool.address)
+  corePool.setQuickReward(ethers.BigNumber.from(QUICK_REWARDS))
 
-  const addresses = {
-    SyndicatePoolFactory: poolFactory.address,
-    SyndicateCorePool: corePool.address
-  }
-
-  if (!deployed[chainId]) {
-    deployed[chainId] = {}
-  }
-  deployed[chainId] = Object.assign(deployed[chainId], addresses)
-
-  console.log(deployed)
-
-  const deployedJson = path.resolve(__dirname, '../export/deployed.json')
-  await fs.ensureDir(path.dirname(deployedJson))
-  await fs.writeFile(deployedJson, JSON.stringify(deployed, null, 2))
+  await deployUtils.saveDeployed(chainId,
+      ['SyndicatePoolFactory', 'SyndicateCorePool'],
+      [poolFactory.address,corePool.address]
+  )
 
 }
 
-// We recommend this pattern to be able to use async/await everywhere
-// and properly handle errors.
 main()
     .then(() => process.exit(0))
     .catch(error => {

--- a/scripts/deploy-ssyn.js
+++ b/scripts/deploy-ssyn.js
@@ -1,74 +1,20 @@
-
 require('dotenv').config()
-const {assert} = require("chai")
 const hre = require("hardhat");
-const fs = require('fs-extra')
-const path = require('path')
-const requireOrMock = require('require-or-mock')
 const ethers = hre.ethers
-const deployed = requireOrMock('export/deployed.json')
-//const os = require("os");
 
-//const envFilePath = path.resolve(__dirname, "../.env");
-// read .env file & convert to array
-//const readEnvVars = () => fs.readFileSync(envFilePath, "utf-8").split(os.EOL);
-
-async function currentChainId() {
-  return (await ethers.provider.getNetwork()).chainId
-}
-
-async function currentChainId() {
-    return (await ethers.provider.getNetwork()).chainId
-  }
-function normalize(val, n = 18) {
-    return '' + val + '0'.repeat(n)
-  }
-
-  const setEnvValue = (key, value) => {
-    const envVars = readEnvVars();
-    const targetLine = envVars.find((line) => line.split("=")[0] === key);
-    if (targetLine !== undefined) {
-      // update existing line
-      const targetLineIndex = envVars.indexOf(targetLine);
-      // replace the key/value with the new value
-      envVars.splice(targetLineIndex, 1, `${key}=${value}`);
-    } else {
-      // create new key value
-      envVars.push(`${key}=${value}`);
-    }
-    // write everything back to the file system
-    fs.writeFileSync(envFilePath, envVars.join(os.EOL));
-  };
+const DeployUtils = require('./lib/DeployUtils')
+let deployUtils
 
 async function main() {
-  const chainId = await currentChainId()
-  const isLocalNode = /1337$/.test(chainId)
-  let [owner, user1, user2] = await ethers.getSigners();
-
-
-    const SSYN = await ethers.getContractFactory("EscrowedSyndicateERC20")
-    const ssyn = await SSYN.deploy()
-    await ssyn.deployed()
-    console.log('ssyn deployed')
-
-    const addresses = {
-      EscrowedSyndicateERC20: ssyn.address,
-    }
-    //setEnvValue('SSYNADRESS', addresses.SSYN)
-    if (!deployed[chainId]) {
-      deployed[chainId] = {}
-    }
-    deployed[chainId] = Object.assign(deployed[chainId], addresses)
-  
-    console.log(deployed)
-  
-    const deployedJson = path.resolve(__dirname, '../export/deployed.json')
-    await fs.ensureDir(path.dirname(deployedJson))
-    await fs.writeFile(deployedJson, JSON.stringify(deployed, null, 2))
+  deployUtils = new DeployUtils(ethers)
+  const chainId = await deployUtils.currentChainId()
+  const SSYN = await ethers.getContractFactory("EscrowedSyndicateERC20")
+  const ssyn = await SSYN.deploy()
+  await ssyn.deployed()
+  console.log('EscrowedSyndicateERC20 deployed at', ssyn.address)
+  await deployUtils.saveDeployed(chainId, ['EscrowedSyndicateERC20'], [ssyn.address])
 }
 
-// We recommend this pattern to be able to use async/await everywhere
-// and properly handle errors.
 main()
     .then(() => process.exit(0))
     .catch(error => {

--- a/scripts/deploy-syn.js
+++ b/scripts/deploy-syn.js
@@ -1,103 +1,32 @@
-// We require the Hardhat Runtime Environment explicitly here. This is optional
-// but useful for running the script in a standalone fashion through `node <script>`.
-//
-// When running the script with `hardhat run <script>` you'll find the Hardhat
-// Runtime Environment's members available in the global scope.
 require('dotenv').config()
-const {assert} = require("chai")
 const hre = require("hardhat");
-const fs = require('fs-extra')
-const path = require('path')
-const requireOrMock = require('require-or-mock');
 const ethers = hre.ethers
-const deployed = requireOrMock('export/deployed.json')
-const os = require("os");
 
-const envFilePath = path.resolve(__dirname, "../.env");
-// read .env file & convert to array
-const readEnvVars = () => fs.readFileSync(envFilePath, "utf-8").split(os.EOL);
-
-async function currentChainId() {
-  return (await ethers.provider.getNetwork()).chainId
-}
-
-function normalize(val, n = 18) {
-  return '' + val + '0'.repeat(n)
-}
-
-const setEnvValue = (key, value) => {
-    const envVars = readEnvVars();
-    const targetLine = envVars.find((line) => line.split("=")[0] === key);
-    if (targetLine !== undefined) {
-      // update existing line
-      const targetLineIndex = envVars.indexOf(targetLine);
-      // replace the key/value with the new value
-      envVars.splice(targetLineIndex, 1, `${key}=${value}`);
-    } else {
-      // create new key value
-      envVars.push(`${key}=${value}`);
-    }
-    // write everything back to the file system
-    fs.writeFileSync(envFilePath, envVars.join(os.EOL));
-  };
+const DeployUtils = require('./lib/DeployUtils')
+let deployUtils
 
 async function main() {
-  // Hardhat always runs the compile task when running scripts with its command
-  // line interface.
-  //
-  // If this script is run directly using `node` you may want to call compile
-  // manually to make sure everything is compiled
-  // await hre.run('compile');
+  deployUtils = new DeployUtils(ethers)
+  const chainId = await deployUtils.currentChainId()
+  let [owner] = await ethers.getSigners();
 
-  const chainId = await currentChainId()
-  const isLocalNode = /1337$/.test(chainId)
-
-  let [owner, user1, user2] = await ethers.getSigners();
-
-  // deploy SYN contract
   const SYN = await ethers.getContractFactory("SyndicateERC20")
   const syn = await SYN.deploy(owner.address)
   await syn.deployed()
-  console.log('syn deployed')
-
-  //await syn.transfer(user1.address, normalize(20000));
-  //console.log('syn transferred from owner to user1')
+  console.log('SyndicateERC20 deployed at', syn.address)
 
   let features =
       (await syn.FEATURE_TRANSFERS_ON_BEHALF()) +
       (await syn.FEATURE_TRANSFERS()) +
-      (await syn.FEATURE_UNSAFE_TRANSFERS() +
-          (await syn.FEATURE_DELEGATIONS()) +
-          (await syn.FEATURE_DELEGATIONS_ON_BEHALF()))
+      (await syn.FEATURE_UNSAFE_TRANSFERS()) +
+      (await syn.FEATURE_DELEGATIONS()) +
+      (await syn.FEATURE_DELEGATIONS_ON_BEHALF())
 
   await syn.updateFeatures(features)
-
-  console.log('syn updated')
-
-  await syn.transfer(user1.address, ethers.utils.parseEther('20000'));
-  console.log('syn transferred from owner to user1')
-
-  const addresses = {
-    SyndicateERC20: syn.address,
-  }
-
-  //setEnvValue('SYNADRESS', addresses.SYN)
-  if (!deployed[chainId]) {
-   deployed[chainId] = {}
-  }
-  deployed[chainId] = Object.assign(deployed[chainId], addresses)
-
-  console.log(deployed)
-
-  const deployedJson = path.resolve(__dirname, '../export/deployed.json')
-  await fs.ensureDir(path.dirname(deployedJson))
-  await fs.writeFile(deployedJson, JSON.stringify(deployed, null, 2))
-
+  // await syn.transfer(user1.address, ethers.utils.parseEther('20000'));
+  await deployUtils.saveDeployed(chainId, ['SyndicateERC20'], [syn.address])
 }
 
-
-// We recommend this pattern to be able to use async/await everywhere
-// and properly handle errors.
 main()
     .then(() => process.exit(0))
     .catch(error => {

--- a/scripts/lib/DeployUtils.js
+++ b/scripts/lib/DeployUtils.js
@@ -1,0 +1,38 @@
+const path = require('path');
+const fs = require('fs-extra');
+
+class DeployUtils {
+
+  constructor(ethers) {
+    this.ethers = ethers
+  }
+
+  async currentChainId() {
+    return (await this.ethers.provider.getNetwork()).chainId
+  }
+
+  async saveDeployed(chainId, names, addresses) {
+    if (names.length !== addresses.length) {
+      throw new Error('Inconsistent arrays')
+    }
+    const deployedJson = path.resolve(__dirname, '../../export/deployed.json')
+    if (!(await fs.pathExists(deployedJson))) {
+      await fs.ensureDir(path.dirname(deployedJson))
+      await fs.writeFile(deployedJson, '{}')
+    }
+    const deployed = JSON.parse(await fs.readFile(deployedJson, 'utf8'))
+    if (!deployed[chainId]) {
+      deployed[chainId] = {}
+    }
+    const data = {}
+    for (let i=0;i<names.length;i++) {
+      data[names[i]] = addresses[i]
+    }
+    deployed[chainId] = Object.assign(deployed[chainId], data)
+    // console.log(deployed)
+    await fs.writeFile(deployedJson, JSON.stringify(deployed, null, 2))
+  }
+
+}
+
+module.exports = DeployUtils


### PR DESCRIPTION
This cleans up the scripts, adding `DeployUtils` to keep common components.

It also moves outside the parameters needed during the deployment of the pool factory. For this reason, if deploying a pool, the command to call must be something like
```
bin/deploy.sh pool localhost 5000 100000000 10000000 99999
```
