### PR TITLE
certik audit issue SPB-02

### DIFF
--- a/contracts/pools/SyndicatePoolBase.sol
+++ b/contracts/pools/SyndicatePoolBase.sol
@@ -319,7 +319,6 @@ abstract contract SyndicatePoolBase is IPool, SyndicateAware, ReentrancyGuard {
     bool useSSYN
   ) external {
     // sync and call processRewards
-    _sync();
     _processRewards(msg.sender, useSSYN, true);
     // delegate call to an internal function
     _updateStakeLock(msg.sender, depositId, lockedUntil);

--- a/contracts/pools/SyndicatePoolBase.sol
+++ b/contracts/pools/SyndicatePoolBase.sol
@@ -320,7 +320,7 @@ abstract contract SyndicatePoolBase is IPool, SyndicateAware, ReentrancyGuard {
   ) external {
     // sync and call processRewards
     _sync();
-    _processRewards(msg.sender, useSSYN, false);
+    _processRewards(msg.sender, useSSYN, true);
     // delegate call to an internal function
     _updateStakeLock(msg.sender, depositId, lockedUntil);
   }


### PR DESCRIPTION
Description:
The function updateStakeLock() calls the function _processRewards() and passes false as the variable _withUpdate. So, the function _processRewards() will accumulate the user's rewards without updating user.subYieldRewards. It may let the user can get the rewards repeatedly.
Recommendation
Add the updates of user.subYieldRewards