### PR TITLE
Fixing tests and adding deploy-tokens.js

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -10,7 +10,7 @@ if [[ "$1" == "pool" ]]; then
 # 1080 is 30%, 990 is 27.5%
   SYN_PER_BLOCK=$3 BLOCK_PER_UPDATE=$4 BLOCK_MULTIPLIER=$5 WEIGHT=$6 \
     npx hardhat run scripts/deploy-$1.js --network $2
-elif [[ "$1" == "syn" ]]; then
+elif [[ "$1" == "syn" || "$1" == "tokens" ]]; then
 # bin/deploy.sh syn localhost 10000000000
   MAX_TOTAL_SUPPLY=$3 npx hardhat run scripts/deploy-$1.js --network $2
 else

--- a/contracts/token/SynSwapper.sol
+++ b/contracts/token/SynSwapper.sol
@@ -5,7 +5,7 @@ import "./SyndicateERC20.sol";
 import "./SyntheticSyndicateERC20.sol";
 import "../utils/AccessControl.sol";
 
-import "hardhat/console.sol";
+// import "hardhat/console.sol";
 
 /**
  * @title Syn Swapper

--- a/contracts/token/SynSwapper.sol
+++ b/contracts/token/SynSwapper.sol
@@ -20,26 +20,27 @@ contract SynSwapper is AccessControl {
   event SynSwapped(address swapper, uint256 amount);
 
   address public owner;
-  address public syn;
-  address public ssyn;
+  SyndicateERC20 public syn;
+  SyntheticSyndicateERC20 public ssyn;
 
   constructor(
     address _superAdmin,
     address _syn,
     address _ssyn
   ) AccessControl(_superAdmin) {
-    syn = _syn;
-    ssyn = _ssyn;
+    syn = SyndicateERC20(_syn);
+    ssyn = SyntheticSyndicateERC20(_ssyn);
   }
 
   /**
    * @notice Swaps an amount of sSYN for an identical amount of SYN
-   * @param recipient  The address of account to burn the sSYN and receive the SSYN
+   *         Everyone can execute it, but it will have effect only if the recipient
+   *         has the required roles.
    * @param amount     The amount of token to be swapped
    */
-  function swap(address recipient, uint256 amount) external {
-    require(isSenderInRole(ROLE_ACCESS_MANAGER), "sSYN: insufficient privileges (ROLE_ACCESS_MANAGER required)");
-     SyntheticSyndicateERC20(ssyn).burn(recipient, amount);
-    SyndicateERC20(syn).mint(recipient, amount);
+  function swap(uint256 amount) external {
+    require(syn.isOperatorInRole(msg.sender, syn.ROLE_TREASURY()), "SYN: not a treasury");
+    ssyn.burn(msg.sender, amount);
+    syn.mint(msg.sender, amount);
   }
 }

--- a/contracts/token/SyndicateERC20.sol
+++ b/contracts/token/SyndicateERC20.sol
@@ -295,13 +295,13 @@ contract SyndicateERC20 is AccessControl {
    */
   uint32 public constant ROLE_ERC20_SENDER = 0x0008_0000;
 
-  uint32 public constant ROLE_WHITE_LISTED_SPENDER = 0x0016_0000;
+  uint32 public constant ROLE_WHITE_LISTED_SPENDER = 0x0010_0000;
 
   /**
- * @notice White listed treasury can swap sSYN to receive SYN
- * @dev Role ROLE_TREASURY can get SYN in exchange for sSYN
- */
-  uint32 public constant ROLE_TREASURY = 0x0032_0000;
+   * @notice White listed treasury can swap sSYN to receive SYN
+   * @dev Role ROLE_TREASURY can get SYN in exchange for sSYN
+   */
+  uint32 public constant ROLE_TREASURY = 0x0020_0000;
 
   /**
    * @dev Magic value to be returned by ERC20Receiver upon successful reception of token(s)
@@ -815,7 +815,7 @@ contract SyndicateERC20 is AccessControl {
    *      to specify an address to mint tokens to
    * @dev Requires sender to have `ROLE_TOKEN_CREATOR` permission
    *
-   * @dev Throws on overflow, if totalSupply + _value doesn't fit into uint256
+   * @dev Throws on overflow, if totalSupply + _value doesn't fit into uint192
    *
    * @param _to an address to mint tokens to
    * @param _value an amount of tokens to mint (create)

--- a/contracts/utils/AccessControl.sol
+++ b/contracts/utils/AccessControl.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.1;
 
-import "hardhat/console.sol";
+// import "hardhat/console.sol";
 
 /**
  * @title Access Control List

--- a/contracts/utils/AccessControl.sol
+++ b/contracts/utils/AccessControl.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.1;
 
+import "hardhat/console.sol";
+
 /**
  * @title Access Control List
  *

--- a/contracts/vesting/AdvisorsVesting.sol
+++ b/contracts/vesting/AdvisorsVesting.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.1;
 import "../token/SyndicateERC20.sol";
 import "../utils/Ownable.sol";
 
-import "hardhat/console.sol";
+// import "hardhat/console.sol";
 
 contract AdvisorsVesting is Ownable {
   event GrantTerminated(address grantee, uint256 when);

--- a/contracts/vesting/InvestorVesting.sol
+++ b/contracts/vesting/InvestorVesting.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.1;
 import "../token/SyndicateERC20.sol";
 import "../utils/Ownable.sol";
 
-import "hardhat/console.sol";
+// import "hardhat/console.sol";
 
 contract InvestorVesting is Ownable {
   event TGETriggered(uint256 nowTimestamp, uint256 timestampTGE);

--- a/contracts/vesting/TeamVesting.sol
+++ b/contracts/vesting/TeamVesting.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.1;
 import "../token/SyndicateERC20.sol";
 import "../utils/Ownable.sol";
 
-import "hardhat/console.sol";
+// import "hardhat/console.sol";
 
 contract TeamVesting is Ownable {
   uint256 public startTime;

--- a/scripts/deploy-ssyn.js
+++ b/scripts/deploy-ssyn.js
@@ -14,7 +14,7 @@ async function main() {
       : chainId == 42 ? 'kovan'
           : 'localhost'
 
-  const superAdmin = chainId === '1337'
+  const superAdmin = chainId === 1337
       ? localSuperAdmin.address
       : process.env.SUPER_ADMIN
 

--- a/scripts/deploy-swapper.js
+++ b/scripts/deploy-swapper.js
@@ -18,11 +18,11 @@ async function main() {
 
   let [, localTokenOwner, localSuperAdmin] = await ethers.getSigners();
 
-  const tokenOwner = chainId === '1337'
+  const tokenOwner = chainId === 1337
       ? localTokenOwner.address
       : process.env.TOKEN_OWNER
 
-  const superAdmin = chainId === '1337'
+  const superAdmin = chainId === 1337
       ? localSuperAdmin.address
       : process.env.SUPER_ADMIN
 

--- a/scripts/deploy-syn.js
+++ b/scripts/deploy-syn.js
@@ -11,11 +11,11 @@ async function main() {
   let [, localTokenOwner, localSuperAdmin] = await ethers.getSigners();
   // let tx;
 
-  const tokenOwner = chainId === '1337'
+  const tokenOwner = chainId === 1337
       ? localTokenOwner.address
       : process.env.TOKEN_OWNER
 
-  const superAdmin = chainId === '1337'
+  const superAdmin = chainId === 1337
       ? localSuperAdmin.address
       : process.env.SUPER_ADMIN
 

--- a/scripts/deploy-tokens.js
+++ b/scripts/deploy-tokens.js
@@ -1,0 +1,124 @@
+require('dotenv').config()
+const hre = require("hardhat");
+const ethers = hre.ethers
+
+const DeployUtils = require('./lib/DeployUtils')
+let deployUtils
+
+async function main() {
+  deployUtils = new DeployUtils(ethers)
+  const chainId = await deployUtils.currentChainId()
+  let [, localTokenOwner, localSuperAdmin, localTreasury] = await ethers.getSigners();
+  // let tx;
+
+  const tokenOwner = chainId === 1337
+      ? localTokenOwner.address
+      : process.env.TOKEN_OWNER
+
+  const superAdmin = chainId === 1337
+      ? localSuperAdmin.address
+      : process.env.SUPER_ADMIN
+
+  const treasury = chainId === 1337
+      ? localTreasury.address
+      : process.env.TREASURY
+
+  const network = chainId === 1 ? 'ethereum'
+      : chainId === 42 ? 'kovan'
+          : 'localhost'
+
+  if (!process.env.MAX_TOTAL_SUPPLY) {
+    throw new Error('Missing parameters')
+  }
+
+  console.log('Deploying SyndicateERC20...')
+  const SYN = await ethers.getContractFactory("SyndicateERC20")
+  const syn = await SYN.deploy(tokenOwner, process.env.MAX_TOTAL_SUPPLY, superAdmin)
+  await syn.deployed()
+  console.log('SyndicateERC20 deployed at', syn.address)
+
+  let notReallyDeployedYet = true
+  let features
+
+  // if the network is congested the following can fail
+  while (notReallyDeployedYet) {
+    try {
+      features =
+          (await syn.FEATURE_TRANSFERS_ON_BEHALF()) +
+          (await syn.FEATURE_TRANSFERS()) +
+          (await syn.FEATURE_UNSAFE_TRANSFERS()) +
+          (await syn.FEATURE_DELEGATIONS()) +
+          (await syn.FEATURE_DELEGATIONS_ON_BEHALF())
+      notReallyDeployedYet = false
+    } catch (e) {
+      await deployUtils.sleep(1000)
+    }
+  }
+  console.log('Updating features')
+  await (await syn.updateFeatures(features)).wait()
+
+  console.log('Giving treasury right to swap sSYN for SYN')
+  await (await syn.updateRole(treasury, await syn.ROLE_TREASURY())).wait()
+
+  console.log(`
+To verify SyndicateERC20 source code:
+    
+  npx hardhat verify --show-stack-traces \\
+      --network ${network} \\
+      ${syn.address} \\
+      ${tokenOwner} \\
+      ${process.env.MAX_TOTAL_SUPPLY}
+      
+`)
+
+  console.log('Deploying SyntheticSyndicateERC20...')
+  const SSYN = await ethers.getContractFactory("SyntheticSyndicateERC20")
+  const ssyn = await SSYN.deploy(superAdmin)
+  await ssyn.deployed()
+
+  console.log('Giving treasury right to receive sSYN')
+  await (await ssyn.updateRole(treasury, await ssyn.ROLE_WHITE_LISTED_RECEIVER())).wait()
+
+  console.log(`
+To verify SyntheticSyndicateERC20 source code:
+    
+  npx hardhat verify --show-stack-traces \\
+      --network ${network} \\
+      ${ssyn.address}  \\
+      ${superAdmin.address}
+      
+`)
+
+  console.log('SyntheticSyndicateERC20 deployed at', ssyn.address)
+
+  console.log('Deploying SynSwapper')
+  const SynSwapper = await ethers.getContractFactory("SynSwapper")
+  const synSwapper = await SynSwapper.deploy(
+      superAdmin,
+      syn.address,
+      ssyn.address);
+  await synSwapper.deployed()
+  console.log('SynSwapper deployed at', synSwapper.address)
+
+  console.log(`
+To verify SynSwapper source code:
+    
+  npx hardhat verify --show-stack-traces \\
+      --network ${network} \\
+      ${synSwapper.address} \\
+      ${superAdmin} \\
+      ${syn.address} \\
+      ${ssyn.address}
+      
+`)
+
+  await deployUtils.saveDeployed(chainId, ['SyndicateERC20', 'SyntheticSyndicateERC20', 'SynSwapper'],
+      [syn.address, ssyn.address, synSwapper.address])
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch(error => {
+      console.error(error);
+      process.exit(1);
+    });


### PR DESCRIPTION
This fixes some detail in the test, adding more proofs that it fails if the caller does not have the right permissions.
It also adds a `deploy-tokens.js` file to avoid setting the treasury manually.