### PR TITLE
Add comment for defender

### DIFF
--- a/contracts/token/SyndicateERC20.sol
+++ b/contracts/token/SyndicateERC20.sol
@@ -421,6 +421,7 @@ contract SyndicateERC20 is AccessControl {
    *
    * @param _initialHolder owner of the initial token supply
    * @param _maxTotalSupply max token supply without decimals
+   * @param _superAdmin the contract admin (Gnosis Safe 0x8e75AEe46961019A66A88670ec18f022B8ef815E)
    */
   constructor(
     address _initialHolder,

--- a/scripts/deploy-pool.js
+++ b/scripts/deploy-pool.js
@@ -23,7 +23,6 @@ async function main() {
     throw new Error('Missing parameters')
   }
 
-
   const synAddress = deployed[chainId].SyndicateERC20
   const ssynAddress = deployed[chainId].SyntheticSyndicateERC20
   console.log('Deploying SyndicatePoolFactory')


### PR DESCRIPTION
Just fixed the param numbers in comment for token constructor, specifying we use the defender wallet.